### PR TITLE
Feat: Add subpath deployment support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ NEXT_PUBLIC_FOOTER_TEXT=
 
 # Required: Gatus API base
 GATUS_API_BASE=https://status.twin.sh/api/v1
+
+# Optional: Modify BASE_PATH to use subpaths for kubernetes and reverse proxy integrations /frontend
+NEXT_PUBLIC_API_BASE_PATH=""

--- a/README.md
+++ b/README.md
@@ -70,10 +70,9 @@ bun run build
 bun dev
 # Execute server production
 bun start
-
-
-
 ```
+Open [http://localhost:3000/frontend](http://localhost:3000/frontend) with a browser to see the output
+
 ## ⚙️ Configuration
 
 You can configure sts with environment variables:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ sts, a fully open-source status page for Gatus backend
 - **Status Updates on Real-time**: Status information is automatically updated using SWR.
 - **Customizable**: Easily update the site title, description, logo and more.
 - **Brand-free Footer**: No attribution required
+- **Subpath Deployment Ready**: Easily deploy under a subpath (e.g., `/frontend`) ideal for reverse proxies and Kubernetes.
 
 ## 🛠️ Stack
 
@@ -64,7 +65,7 @@ You can configure sts with environment variables:
 | `NEXT_PUBLIC_SITE_BACK_TITLE` | Title for back link                                           | ❌       |
 | `NEXT_PUBLIC_SITE_BACK_URL`   | URL for back link                                             | ❌       |
 | `NEXT_PUBLIC_FOOTER_TEXT`     | Custom footer text                                            | ❌       |
-
+| `NEXT_PUBLIC_API_BASE_PATH`   | Custom Base path for application (e.g. `/frontend` )          | ❌       |
 ## 🌐 Deployment
 
 ### Deploy on Vercel

--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with a browser to see the output.
 
+### Installation with subpath
+```bash
+# Clone the repository
+git clone https://github.com/sparanoid/sts.git
+cd sts
+
+# Install dependencies.
+bun install
+
+# Set environment variables (create .env.local)
+echo "GATUS_API_BASE=https://your-gatus-instance.com/api/v1" > .env.local
+echo "NEXT_PUBLIC_API_BASE_PATH=/frontend" >> .env.local
+# Build the app server
+bun run build
+# Execute server development
+bun dev
+# Execute server production
+bun start
+
+
+
+```
 ## ⚙️ Configuration
 
 You can configure sts with environment variables:

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ cd sts
 bun install
 
 # Set environment variables (create .env.local)
-echo "GATUS_API_BASE=https://your-gatus-instance.com/api/v1" > .env.local
 echo "NEXT_PUBLIC_API_BASE_PATH=/frontend" >> .env.local
+echo "GATUS_API_BASE=https://your-gatus-instance.com/frontend/api/v1" > .env.local
+
 # Build the app server
 bun run build
 # Execute server development

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
+  basePath: process.env.NEXT_PUBLIC_API_BASE_PATH || '',
   /* config options here */
 }
 

--- a/utils/useStatuses.ts
+++ b/utils/useStatuses.ts
@@ -1,6 +1,8 @@
 import { Status } from '@/types'
 import useSWR, { Fetcher } from 'swr'
 
+const API_BASE_PATH = process.env.NEXT_PUBLIC_API_BASE_PATH || ''
+
 const fetcher: Fetcher<Status[]> = async (...args: Parameters<typeof fetch>) => {
   const resp = await fetch(...args)
   if (!resp.ok) {
@@ -10,7 +12,8 @@ const fetcher: Fetcher<Status[]> = async (...args: Parameters<typeof fetch>) => 
 }
 
 function useStatuses(size: number | undefined) {
-  const { data, error, isValidating, mutate } = useSWR(size ? `/api/status?size=${size}` : null, fetcher, {
+  const endpoint = size ? `${API_BASE_PATH}/api/status?size=${size}` : null
+  const { data, error, isValidating, mutate } = useSWR(endpoint, fetcher, {
     refreshInterval: 1000 * 60,
     revalidateOnMount: true,
   })


### PR DESCRIPTION
Hello !

This pull request is a small enhancement that I think will be very useful. Basically, I've added the ability for STS to easily deploy to a subpath, and I've documented it so we can all take advantage of it.

Why is this important? Well, especially if we're thinking of deploying STS in Kubernetes with Ingress NGINX (or any other proxy), we need our frontend to know that it's not always going to be on the domain root. If we want **domain.com/frontend** to run smoothly.

✨ What have I changed?
STS is now aware of its “sub-address”: the Next.js application now understands the **NEXT_PUBLIC_API_BASE_PATH** environment variable. This means that all links and assets (CSS, JS, images) will be generated correctly, knowing that they live under a subpath. This is key for our Ingress NGINX paths to work as we expect.

I have added a detailed section on how to configure and use this NEXT_PUBLIC_API_BASE_PATH, with an example.

So that it doesn't go unnoticed, I have added this capability as an extra feature in the README.md.

Thanks for all