### PR TITLE
feat: add compatability with gatus security.basic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ NEXT_PUBLIC_FOOTER_TEXT=
 # Required: Gatus API base
 GATUS_API_BASE=https://status.twin.sh/api/v1
 
+# Optional: credentials if Gatus is protected with security.basic
+GATUS_API_USERNAME=
+GATUS_API_PASSWORD=
+
 # Optional: Modify BASE_PATH to use subpaths for kubernetes and reverse proxy integrations /frontend
 NEXT_PUBLIC_API_BASE_PATH=""
 

--- a/README.md
+++ b/README.md
@@ -109,20 +109,22 @@ Open [http://localhost:3000/frontend](http://localhost:3000/frontend) with a bro
 
 You can configure sts with environment variables:
 
-| Variable                      | Description                                                   | Required |
-| ----------------------------- | ------------------------------------------------------------- | -------- |
-| `GATUS_API_BASE`              | Gatus API base URL (e.g. `https://status.example.com/api/v1`) | ✅       |
-| `PAYLOAD_SECRET`              | Secret key for Payload CMS (min. 32 characters)               | ✅       |
-| `TURSO_DATABASE_URL`          | Or `DATABASE_URI` for Turso database URL (for cloud SQLite)   | ❌       |
-| `TURSO_AUTH_TOKEN`            | Or `AUTH_TOKEN` for Turso authentication token                | ❌       |
-| `NEXT_PUBLIC_SITE_TITLE`      | Site title                                                    | ❌       |
-| `NEXT_PUBLIC_SITE_DESC`       | Site description                                              | ❌       |
-| `NEXT_PUBLIC_SITE_LOGO`       | Site logo URL                                                 | ❌       |
-| `NEXT_PUBLIC_SITE_BACK_TITLE` | Title for back link                                           | ❌       |
-| `NEXT_PUBLIC_SITE_BACK_URL`   | URL for back link                                             | ❌       |
-| `NEXT_PUBLIC_FOOTER_TEXT`     | Custom footer text                                            | ❌       |
-| `NEXT_PUBLIC_API_BASE_PATH`   | Custom Base path for application (e.g. `/frontend` )          | ❌       |
-| `NEXT_PUBLIC_GROUP_SIZE`      | Loading skeleton group size (Default: `3` )                   | ❌       |
+| Variable                      | Description                                                    | Required |
+| ----------------------------- | -------------------------------------------------------------- | -------- |
+| `GATUS_API_BASE`              | Gatus API base URL (e.g., `https://status.example.com/api/v1`) | ✅       |
+| `GATUS_API_USERNAME`          | Username for Gatus API                                         | ❌       |
+| `GATUS_API_PASSWORD`          | Password for Gatus API                                         | ❌       |
+| `PAYLOAD_SECRET`              | Secret key for Payload CMS (min. 32 characters)                | ✅       |
+| `TURSO_DATABASE_URL`          | Or `DATABASE_URI` for Turso database URL (for cloud SQLite)    | ❌       |
+| `TURSO_AUTH_TOKEN`            | Or `AUTH_TOKEN` for Turso authentication token                 | ❌       |
+| `NEXT_PUBLIC_SITE_TITLE`      | Site title                                                     | ❌       |
+| `NEXT_PUBLIC_SITE_DESC`       | Site description                                               | ❌       |
+| `NEXT_PUBLIC_SITE_LOGO`       | Site logo URL                                                  | ❌       |
+| `NEXT_PUBLIC_SITE_BACK_TITLE` | Title for back link                                            | ❌       |
+| `NEXT_PUBLIC_SITE_BACK_URL`   | URL for back link                                              | ❌       |
+| `NEXT_PUBLIC_FOOTER_TEXT`     | Custom footer text                                             | ❌       |
+| `NEXT_PUBLIC_API_BASE_PATH`   | Custom Base path for application (e.g. `/frontend` )           | ❌       |
+| `NEXT_PUBLIC_GROUP_SIZE`      | Loading skeleton group size (Default: `3` )                    | ❌       |
 
 ## 🌐 Deployment
 

--- a/lib/getStatuses.ts
+++ b/lib/getStatuses.ts
@@ -10,7 +10,7 @@ export async function getStatuses(size: number) {
   }
 
   const url = `${apiBase}/endpoints/statuses?page=1&pageSize=${size}`
-  const headers: HeadersInit = {
+  const headers: Record<string, string> = {
     "User-Agent": `sparanoid-sts/${version}`,
   };
 

--- a/lib/getStatuses.ts
+++ b/lib/getStatuses.ts
@@ -10,10 +10,17 @@ export async function getStatuses(size: number) {
   }
 
   const url = `${apiBase}/endpoints/statuses?page=1&pageSize=${size}`
+  const headers: HeadersInit = {
+    "User-Agent": `sparanoid-sts/${version}`,
+  };
+
+  const { GATUS_API_USERNAME, GATUS_API_PASSWORD } = process.env;
+  if (GATUS_API_USERNAME && GATUS_API_PASSWORD) {
+    headers.Authorization = `Basic ${Buffer.from(`${GATUS_API_USERNAME}:${GATUS_API_PASSWORD}`).toString("base64")}`;
+  }
+
   const res = await fetch(url, {
-    headers: {
-      'User-Agent': `sparanoid-sts/${version}`,
-    },
+    headers,
     next: { revalidate: 10 },
   })
 


### PR DESCRIPTION
This PR adds the ability for STS to authenticate with Gatus via security.basic, which is useful for people that want to only expose STS publicly and not Gatus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for authenticating with a protected Gatus API using optional username and password environment variables.
  * Requests now include a clearer user agent identifier.

* **Documentation**
  * Updated configuration docs for environment variables and improved formatting for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->